### PR TITLE
FoodGrid second Page

### DIFF
--- a/src/app/utils/components/index/Main/FoodGrid.tsx
+++ b/src/app/utils/components/index/Main/FoodGrid.tsx
@@ -120,6 +120,7 @@ const FoodGrid: React.FC<Props> = observer(function FoodGrid({ searchTerm, recip
     const handlePageChange = (newPage: number) => {
         if (newPage >= 1 && newPage <= pagination.totalPages) {
             setPagination((prev) => ({ ...prev, currentPage: newPage }));
+            getAllRecipes(newPage);
         }
     };
 


### PR DESCRIPTION
fetch updated recipes whenever the page is changed. This is for when the user goes to MyRecipe and back so that the second page is usable.